### PR TITLE
Aligning vertically the loading screen (Generating page) to improve eye candy

### DIFF
--- a/harbour-sudoku.pro
+++ b/harbour-sudoku.pro
@@ -11,6 +11,7 @@ OTHER_FILES   += \
     qml/pages/NumberInput.qml \
     qml/pages/SudokuBoard.qml \
     qml/pages/PlayGamePage.qml \
+    qml/pages/Generating.qml \
     qml/pages/AboutPage.qml \
     qml/pages/Sudoku.js \
     qml/harbour-sudoku.qml \

--- a/qml/pages/Generating.qml
+++ b/qml/pages/Generating.qml
@@ -6,6 +6,7 @@ Page {
 
     Column {
         anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
         spacing: 20
 
         Label {


### PR DESCRIPTION
I am a little OCD, but it bugs me everytime I finish a sudoku game to see the generating loading screen right at the top. This change in my opinion makes the loading screen more aesthetically pleasing.